### PR TITLE
Fix Malindo Air not showing flight's time correctly

### DIFF
--- a/lib/teecket/selectors/malindo_air.rb
+++ b/lib/teecket/selectors/malindo_air.rb
@@ -29,6 +29,7 @@ module Selectors
     def depart_arrive_at_formatter(datetime)
       DateTime
         .strptime(datetime.gsub(%r(^\/Date\(|\)\/), ""), "%Q")
+        .to_time
         .strftime("%I:%M %p")
     end
 


### PR DESCRIPTION
Probably due to timezone conversion
